### PR TITLE
Topic/polyhedron parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
   - secure: docMUTjBQtm4uaLVtyRvv/rbq7JfmsuWGVPd/8Ay2lwZdkquAeFnK8YSptvi5+8x9VvJrv3Xu+gQZXtZSkETfpNEzORaaOVgZ4na8QzxKNQdw45leucZ28EbEQ7fBvg7e3s2l4EWjjjrAPz82+KTyQXUlNplRYaJk0CTBsbI29o=
   - secure: bMjZcr/JjHXZht+jJovEYW3NFpQam+btwZMuFLC2zlj+FsCcnWOUEtRqygE5sm/BukULxRrLTK5NxeaA7VGrbrlrAuJh5KK5NltCP03QTwvH/Zaah/JrihHZ1IkZt//Rxi8UcF2P45LEvCGulcLF8sY4YRJPklcm5VJViNimzn8=
   - LCOV_IGNORE_RULES="*tests* *examples*"
-  - MASTER_PPA="george-edison55/precise-backports"
 notifications:
   slack:
     secure: SAnQfxV4qW1gGCZ+6cTOJ01b9GUxGHfr15QOLNp2ird4HoTNwpF+hSATGXhsYUrqaBlaC62dSi3TfMDMVrDHbTXzlgLAqPf46ZeKzjU+3tXvXPDNbfFIy5vd3xIJ0K61Jgvt2xZ5tHo89zRdorTHHQ9nALzAgm6FKeIyGzmL4Xs=

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,8 @@ env:
   - LCOV_IGNORE_RULES="*tests* *examples*"
   - MASTER_PPA="george-edison55/precise-backports"
 notifications:
-  email:
-  - francois.keith@gmail.com
-branches:
-  only:
-  - master
-  - debian
-  - benchmark
-  - benchmark_eigen
+  slack:
+    secure: SAnQfxV4qW1gGCZ+6cTOJ01b9GUxGHfr15QOLNp2ird4HoTNwpF+hSATGXhsYUrqaBlaC62dSi3TfMDMVrDHbTXzlgLAqPf46ZeKzjU+3tXvXPDNbfFIy5vd3xIJ0K61Jgvt2xZ5tHo89zRdorTHHQ9nALzAgm6FKeIyGzmL4Xs=
 script: ./.travis/run build
 after_success: ./.travis/run after_success
 after_failure: ./.travis/run after_failure

--- a/src/File_Parsing/SimplestParsing.cpp
+++ b/src/File_Parsing/SimplestParsing.cpp
@@ -29,20 +29,7 @@ void SimplestParsing::load(const char* filename)
 
   }
 
-  std::string strbuf;
-  const unsigned BUF_SIZE = 500000;
-  char buf[BUF_SIZE];
-
-
-
-  do
-  {
-    tmp_is.read(buf, BUF_SIZE);
-    strbuf += std::string(buf, tmp_is.gcount());
-  }
-  while(!tmp_is.eof());
-
-  stream_.str(strbuf);
+  stream_ << tmp_is.rdbuf();
 }
 
 std::stringstream& SimplestParsing::operator()()


### PR DESCRIPTION
This PR makes `S_Polyhedron` (through `Polyhedron_algorithms`) loading much faster (40-50% in my benchmarks depending on the file size) by parsing the file line by line instead of seeking for specific strings. Thigh might make the parser a bit more brittle but it works (as stated by the doc) with file generated by `qconvex ... Qt o f` in qhull 2012.1+ (probably before as well but I don't have such files to test).