### PR TITLE
fixing out of bounds access

### DIFF
--- a/src/STP-BV/STP_Torus.cpp
+++ b/src/STP-BV/STP_Torus.cpp
@@ -435,7 +435,7 @@ bool STP_Torus::isHereFarthestNeighbour(const Vector3& v)
           {
             int tmp = m_nextBV[0];
             m_nextBV[0] = m_nextBV[2];
-            m_nextBV[1] = m_nextBV[4];
+            m_nextBV[1] = m_nextBV[3];
             m_nextBV[2] = tmp;
           }
           else


### PR DESCRIPTION
When recompiling sch-core, clang noticed an OOB access so I thought it was a good idea to fix it.

I haven't read the full code to properly understand what it does but this change seemed to be the right one.