### PR TITLE
Fix small issues with default values, layout and warnings

### DIFF
--- a/examples/example0.cpp
+++ b/examples/example0.cpp
@@ -51,7 +51,7 @@
 using namespace sch;
 
 int
-main (int argc, char *argv[])
+main (int /*argc*/, char * /*argv*/[])
 {
   #ifdef ENABLE_SIGFPE
   feenableexcept(FE_ALL_EXCEPT & ~FE_INEXACT);

--- a/include/sch/Matrix/SCH_Types.h
+++ b/include/sch/Matrix/SCH_Types.h
@@ -36,6 +36,7 @@ namespace sch
 
   static const Scalar infinity = DBL_MAX;
   static const Scalar epsilon = 1e-24;
+  static const Scalar defaultPrecision = 1e-6;
   static const Scalar pi = 3.141592653589793238462643383279502884;
 }
 

--- a/include/sch/S_Object/S_Object.h
+++ b/include/sch/S_Object/S_Object.h
@@ -228,8 +228,8 @@ namespace sch
       TBox,
       TSuperellipsoid,
       TSTP_BV_WithPolyhedron,
-      T_Point,
-      T_Capsule,
+      TPoint,
+      TCapsule,
       TCone
     };
 

--- a/include/sch/S_Object/S_ObjectNormalized.hxx
+++ b/include/sch/S_Object/S_ObjectNormalized.hxx
@@ -3,7 +3,7 @@ inline Point3 S_ObjectNormalized::support(const Vector3& v) const
   Vector3 vp(v);
   vp=v*mRot_; //ie : mRot.transpose*v (applying inverse transformation on the support vector)
   Scalar norm=vp.norm();
-  if (norm>0)
+  if (norm>sch::epsilon)
   {
     vp/=norm;
   }
@@ -23,7 +23,7 @@ inline Point3 S_ObjectNormalized::support(const Vector3& v,int &LastFeature) con
   Vector3 vp(v);
   vp= v * mRot_; //ie : mRot.transpose*v (applying inverse transformation on the support vector)
   Scalar norm=vp.norm();
-  if (norm>0)
+  if (norm> sch::epsilon )
   {
     vp/=norm;
   }

--- a/include/sch/S_Object/S_ObjectNormalized.hxx
+++ b/include/sch/S_Object/S_ObjectNormalized.hxx
@@ -23,7 +23,7 @@ inline Point3 S_ObjectNormalized::support(const Vector3& v,int &LastFeature) con
   Vector3 vp(v);
   vp= v * mRot_; //ie : mRot.transpose*v (applying inverse transformation on the support vector)
   Scalar norm=vp.norm();
-  if (norm> sch::epsilon )
+  if (norm> sch::epsilon)
   {
     vp/=norm;
   }

--- a/src/CD/CD_Pair.cpp
+++ b/src/CD/CD_Pair.cpp
@@ -17,8 +17,6 @@
 //no theoretical guarantee on the precision nor the collision-safeness when used - Default value is 20
 
 
-#define _DEFAULT_PRECISION_ 1e-6
-
 using namespace sch;
 
 inline Vector3 LinearSystem(Matrix3x3& A, Vector3& y)
@@ -31,12 +29,12 @@ inline Vector3 LinearSystem(Matrix3x3& A, Vector3& y)
 
 CD_Pair::CD_Pair(S_Object *obj1, S_Object *obj2):sObj1_(obj1),sObj2_(obj2),lastDirection_(1.0,0.0,0.0),
   lastFeature1_(-1),lastFeature2_(-1),distance_(0),stamp1_(sObj1_->checkStamp()),stamp2_(sObj2_->checkStamp()),
-  precision_(_DEFAULT_PRECISION_),epsilon_(sch::epsilon),witPointsAreComputed_(false),s1_(Point3()),s2_(Point3()),s_(Point3()),sp_(Point3()),depthPair(obj1,obj2)
+  precision_(defaultPrecision),epsilon_(sch::epsilon),witPointsAreComputed_(false),s1_(Point3()),s2_(Point3()),s_(Point3()),sp_(Point3()),depthPair(obj1,obj2)
 {
   --stamp1_;
   --stamp2_;
 
-  depthPair.setRelativePrecision(_DEFAULT_PRECISION_);
+  depthPair.setRelativePrecision(defaultPrecision);
   depthPair.setEpsilon(sch::epsilon);
 }
 

--- a/src/CD/CD_Pair.cpp
+++ b/src/CD/CD_Pair.cpp
@@ -17,8 +17,7 @@
 //no theoretical guarantee on the precision nor the collision-safeness when used - Default value is 20
 
 
-#define _EPSILON_ 1e-24
-#define _PRECISION_ 1e-6
+#define _DEFAULT_PRECISION_ 1e-6
 
 using namespace sch;
 
@@ -32,13 +31,13 @@ inline Vector3 LinearSystem(Matrix3x3& A, Vector3& y)
 
 CD_Pair::CD_Pair(S_Object *obj1, S_Object *obj2):sObj1_(obj1),sObj2_(obj2),lastDirection_(1.0,0.0,0.0),
   lastFeature1_(-1),lastFeature2_(-1),distance_(0),stamp1_(sObj1_->checkStamp()),stamp2_(sObj2_->checkStamp()),
-  precision_(_PRECISION_),epsilon_(_EPSILON_),witPointsAreComputed_(false),s1_(Point3()),s2_(Point3()),s_(Point3()),sp_(Point3()),depthPair(obj1,obj2)
+  precision_(_DEFAULT_PRECISION_),epsilon_(sch::epsilon),witPointsAreComputed_(false),s1_(Point3()),s2_(Point3()),s_(Point3()),sp_(Point3()),depthPair(obj1,obj2)
 {
   --stamp1_;
   --stamp2_;
 
-  depthPair.setRelativePrecision(_PRECISION_);
-  depthPair.setEpsilon(_EPSILON_);
+  depthPair.setRelativePrecision(_DEFAULT_PRECISION_);
+  depthPair.setEpsilon(sch::epsilon);
 }
 
 

--- a/src/CD_Penetration/CD_Depth.cpp
+++ b/src/CD_Penetration/CD_Depth.cpp
@@ -399,7 +399,7 @@ Scalar CD_Depth::getPenetrationDepth(Vector3& v, Point3 &p1,  Point3 &p2,const C
       qBuf[num_verts] = sObj2_->support(-triangle->getClosest());
       yBuf[num_verts] = pBuf[num_verts] - qBuf[num_verts];
 
-      int index = num_verts++;
+      Index_t index = num_verts++;
       Scalar far_dist = (yBuf[index]* triangle->getClosest());
 
       // Make sure the support mapping is OK.

--- a/src/CD_Penetration/CD_Depth.cpp
+++ b/src/CD_Penetration/CD_Depth.cpp
@@ -2,9 +2,6 @@
 #include <algorithm>
 
 
-#define _DEFAULT_PRECISION_ 1e-6
-
-
 using namespace sch;
 
 #ifndef SCH_BUILD_BSD
@@ -461,7 +458,7 @@ Scalar CD_Depth::getPenetrationDepth(Vector3& v, Point3 &p1,  Point3 &p2,const C
 #endif
 
 
-CD_Depth::CD_Depth(S_Object *Obj1, S_Object *Obj2):sObj1_(Obj1),sObj2_(Obj2),precision_(_DEFAULT_PRECISION_),epsilon_(sch::epsilon)
+CD_Depth::CD_Depth(S_Object *Obj1, S_Object *Obj2):sObj1_(Obj1),sObj2_(Obj2),precision_(defaultPrecision),epsilon_(sch::epsilon)
 {
 
 }

--- a/src/CD_Penetration/CD_Depth.cpp
+++ b/src/CD_Penetration/CD_Depth.cpp
@@ -1,8 +1,9 @@
 #include <sch/CD_Penetration/CD_Depth.h>
 #include <algorithm>
 
-#define _EPSILON_ 1e-24
-#define _PRECISION_ 1e-6
+
+#define _DEFAULT_PRECISION_ 1e-6
+
 
 using namespace sch;
 
@@ -460,7 +461,7 @@ Scalar CD_Depth::getPenetrationDepth(Vector3& v, Point3 &p1,  Point3 &p2,const C
 #endif
 
 
-CD_Depth::CD_Depth(S_Object *Obj1, S_Object *Obj2):sObj1_(Obj1),sObj2_(Obj2),precision_(_PRECISION_),epsilon_(_EPSILON_)
+CD_Depth::CD_Depth(S_Object *Obj1, S_Object *Obj2):sObj1_(Obj1),sObj2_(Obj2),precision_(_DEFAULT_PRECISION_),epsilon_(sch::epsilon)
 {
 
 }

--- a/src/S_Object/S_Box.cpp
+++ b/src/S_Object/S_Box.cpp
@@ -28,7 +28,7 @@ S_Object::S_ObjectType S_Box::getType() const
 
 void S_Box::getBoxParameters(Scalar & a, Scalar & b, Scalar & c) const
 {
-  a=a_;
-  b=b_;
-  c=c_;
+  a=a_*2;
+  b=b_*2;
+  c=c_*2;
 }

--- a/src/S_Object/S_Capsule.cpp
+++ b/src/S_Object/S_Capsule.cpp
@@ -30,5 +30,5 @@ Point3 S_Capsule::l_Support(const Vector3& v, int& /*lastFeature*/)const
 
 S_Object::S_ObjectType S_Capsule::getType() const
 {
-  return S_Object::T_Capsule;
+  return S_Object::TCapsule;
 }

--- a/src/S_Object/S_Point.cpp
+++ b/src/S_Object/S_Point.cpp
@@ -26,5 +26,5 @@ Point3 S_Point::l_Support(const Vector3& /*v*/, int& /*lastFeature*/)const
 
 S_Object::S_ObjectType S_Point::getType() const
 {
-  return S_Object::T_Point;
+  return S_Object::TPoint;
 }


### PR DESCRIPTION
-  Improve the default values for precision and epsilon
-  Correct the getter values for box objects (it was returning half the values)
-  Make the naming consistent for objects, no underscore
-  Fix warnings 