### PR TITLE
Remove std::binary_function usage

### DIFF
--- a/include/sch/STP-BV/STP_BV.h
+++ b/include/sch/STP-BV/STP_BV.h
@@ -136,7 +136,7 @@ namespace sch
   *
   *
   */
-  typedef struct s_PointsComparator: public std::binary_function<const Point3&, const Point3&, bool>
+  typedef struct s_PointsComparator
   {
     /*!
     *  \brief Default constructor


### PR DESCRIPTION
This facility is deprecated in C++11 and removed in C++17. Furthermore,
the declaration does not match the actual operator implemented by this
functor.