### PR TITLE
Avoid infinite loops in polyhedron support function

### DIFF
--- a/include/sch/Matrix/SCH_Types.h
+++ b/include/sch/Matrix/SCH_Types.h
@@ -37,6 +37,7 @@ namespace sch
 
   static const Scalar infinity = std::numeric_limits<Scalar>::max();
   static const Scalar epsilon = std::numeric_limits<Scalar>::epsilon();
+  static const Scalar epsilon10 = std::numeric_limits<Scalar>::epsilon()*10;
   static const Scalar defaultPrecision = 1e-6;
   static const Scalar pi = 3.141592653589793238462643383279502884;
 }

--- a/include/sch/Matrix/SCH_Types.h
+++ b/include/sch/Matrix/SCH_Types.h
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cfloat>
 #include <cassert>
+#include <limits>
 
 #include <sch/Matrix/SmallMatrix3x3T.h>
 #include <sch/Matrix/SmallVector3T.h>
@@ -34,8 +35,8 @@ namespace sch
   typedef  CD_Matrix::Matrix4x4T<Scalar> Matrix4x4;
   typedef  CD_Matrix::Vector3T<Scalar,true> Vector3NormOptimized;
 
-  static const Scalar infinity = DBL_MAX;
-  static const Scalar epsilon = 1e-24;
+  static const Scalar infinity = std::numeric_limits<Scalar>::max();
+  static const Scalar epsilon = std::numeric_limits<Scalar>::epsilon();
   static const Scalar defaultPrecision = 1e-6;
   static const Scalar pi = 3.141592653589793238462643383279502884;
 }

--- a/include/sch/S_Polyhedron/Polyhedron_algorithms.h
+++ b/include/sch/S_Polyhedron/Polyhedron_algorithms.h
@@ -89,8 +89,10 @@ namespace sch
     std::vector<S_PolyhedronVertex*> vertexes_;
 
     std::vector<PolyhedronTriangle> triangles_;
-    S_PolyhedronVertex ** fastVertexes_;
+
+    S_PolyhedronVertex **fastVertexes_;
     S_PolyhedronVertex ** lastVertexes_;
+    unsigned numberOfVertices_;
   };
 }
 

--- a/src/CD/CD_Pair.cpp
+++ b/src/CD/CD_Pair.cpp
@@ -280,8 +280,9 @@ Scalar CD_Pair::GJK()
 
 #ifdef CD_PAIR_VERBOUS_MODE
 
-        std::cout<<"Last features"<<lf1<<" "<<lf2<<std::endl;
-        std::cout<<"supports"<<sup1<<" "<<sup2<<std::endl;
+        std::cout<<"Last features "<<lf1<<" "<<lf2<<std::endl;
+        std::cout<<"Supports "<<sup1<<" "<<sup2<<std::endl;
+        std::cout<<"Distance " << distance_ << std::endl;
 #	ifdef CD_ITERATION_LIMIT
         std::cout<<"Iterations"<<cnt<<std::endl;
 #	endif

--- a/src/CD_Penetration/CD_Depth.cpp
+++ b/src/CD_Penetration/CD_Depth.cpp
@@ -259,7 +259,7 @@ Scalar CD_Depth::getPenetrationDepth(Vector3& v, Point3 &p1,  Point3 &p2,const C
     num_verts = 4;
 
   }
-  // Fall through allowed!!
+  // fall through
   case 4:
   {
     int bad_vertex = originInTetrahedron(yBuf[0], yBuf[1], yBuf[2], yBuf[3]);
@@ -304,7 +304,7 @@ Scalar CD_Depth::getPenetrationDepth(Vector3& v, Point3 &p1,  Point3 &p2,const C
     num_verts = 3;
 
   }
-  // Fall through allowed!!
+  // fall through
   case 3:
   {
     // We have a triangle inside the Minkowski sum containing
@@ -396,7 +396,7 @@ Scalar CD_Depth::getPenetrationDepth(Vector3& v, Point3 &p1,  Point3 &p2,const C
       qBuf[num_verts] = sObj2_->support(-triangle->getClosest());
       yBuf[num_verts] = pBuf[num_verts] - qBuf[num_verts];
 
-      Index_t index = num_verts++;
+      Index_t index = Index_t(num_verts++);
       Scalar far_dist = (yBuf[index]* triangle->getClosest());
 
       // Make sure the support mapping is OK.

--- a/src/STP-BV/STP_BV.cpp
+++ b/src/STP-BV/STP_BV.cpp
@@ -643,7 +643,6 @@ void STP_BV::constructFromFile(const std::string& filename)
       computedPoints.clear();
       computeArcPointsBetween(p1, p2, patchesCenter[dvvr[2].m_outerSTP], step, firstArc);
       computeArcPointsBetween(p4, p3, patchesCenter[dvvr[3].m_outerSTP], step, lastArc);
-      double r = sRadius - (patchesCenter[dvvr[0].m_outerSTP] - patchesCenter[dvvr[2].m_outerSTP]).norm();
       computeArcPointsBetween(p1, p4, patchesCenter[dvvr[0].m_outerSTP], step, computedPoints);
       for(int j = 1 ; j < step ; ++j)
       {
@@ -651,10 +650,8 @@ void STP_BV::constructFromFile(const std::string& filename)
                                             patchesCenter[dvvr[1].m_outerSTP],
                                             patchesCenter[dvvr[2].m_outerSTP],
                                             firstArc[j]);
-        r = sRadius - (arcCenter - patchesCenter[dvvr[2].m_outerSTP]).norm();
         computeArcPointsBetween(firstArc[j], lastArc[j], arcCenter, step, computedPoints);
       }
-      r = sRadius - (patchesCenter[dvvr[1].m_outerSTP] - patchesCenter[dvvr[2].m_outerSTP]).norm();
       computeArcPointsBetween(p2, p3, patchesCenter[dvvr[1].m_outerSTP], step, computedPoints);
 
       //create the torus displayList

--- a/src/S_Polyhedron/Polyhedron_algorithms.cpp
+++ b/src/S_Polyhedron/Polyhedron_algorithms.cpp
@@ -265,6 +265,13 @@ Point3 Polyhedron_algorithms::support(const Vector3&v,int &lastFeature)const
   S_PolyhedronVertex* current;
   Scalar supportH;
 
+  if (numberOfVertices_==0)
+  {
+    std::stringstream errmsg;
+    errmsg << "The polyhedron is empty, impossible to compute support function " << std::endl;
+    throw std::length_error(errmsg.str());
+  }
+
   if (lastFeature==-1)
   {
     current=*fastVertexes_;

--- a/src/S_Polyhedron/Polyhedron_algorithms.cpp
+++ b/src/S_Polyhedron/Polyhedron_algorithms.cpp
@@ -10,8 +10,9 @@
 using namespace sch;
 
 Polyhedron_algorithms::Polyhedron_algorithms(void)
-  :fastVertexes_(0x0)
-  ,lastVertexes_(0x0)
+    : fastVertexes_(0x0),
+      lastVertexes_(0x0),
+      numberOfVertices_(0)
 {
 
 }
@@ -218,15 +219,16 @@ void Polyhedron_algorithms::updateFastArrays()
   {
     delete[] fastVertexes_;
   }
-  if (vertexes_.size()>0)
+  numberOfVertices_ = unsigned(vertexes_.size());
+  if (numberOfVertices_ > 0)
   {
-    fastVertexes_=new S_PolyhedronVertex*[vertexes_.size()];
-    for (unsigned int i=0; i<vertexes_.size(); ++i)
+    fastVertexes_ = new S_PolyhedronVertex *[numberOfVertices_];
+    for (unsigned int i = 0; i < numberOfVertices_; ++i)
     {
       fastVertexes_[i]=vertexes_[i];
     }
 
-    lastVertexes_=&(fastVertexes_[vertexes_.size()]);
+    lastVertexes_ = &(fastVertexes_[numberOfVertices_]);
   }
   else
   {
@@ -246,16 +248,13 @@ Point3 Polyhedron_algorithms::naiveSupport(const Vector3&v)const
 
   current++;
 
-  while (current<lastVertexes_)
+  for (unsigned i = 1; i < numberOfVertices_; i++, current++)
   {
-
-    if ((*current)->supportH(v)>supportH)
+    if ((*current)->supportH(v) > supportH)
     {
-      supportH=(*current)->supportH(v);
-      best=(*current)->getCoordinates();
+      supportH = (*current)->supportH(v);
+      best = (*current)->getCoordinates();
     }
-
-    current++;
   }
 
   return best;

--- a/src/S_Polyhedron/Polyhedron_algorithms.cpp
+++ b/src/S_Polyhedron/Polyhedron_algorithms.cpp
@@ -283,20 +283,27 @@ Point3 Polyhedron_algorithms::support(const Vector3&v,int &lastFeature)const
 
   bool b=current->isHere(v);
 
+  unsigned iterations = 0;
+
   while (!b)
   {
     supportH= current->getNextVertexH();
     current = current->getNextVertex();
     b=current->isHere(v,supportH);
+    ++iterations;
+
+    /// if the number of iterations is bigger than the number of vertices it means that we entered an infinite loop
+    ///the best is te return the support computed using the naive version 
+    if (iterations>numberOfVertices_) 
+    {
+      return naiveSupport(v);
+    }
   }
 
   lastFeature=current->getNumber();
 
 
   return current->getCoordinates();
-
-
-
 }
 
 void Polyhedron_algorithms::deleteVertexesWithoutNeighbors()

--- a/src/S_Polyhedron/Polyhedron_algorithms.cpp
+++ b/src/S_Polyhedron/Polyhedron_algorithms.cpp
@@ -6,6 +6,7 @@
 #include <stdexcept>
 #include <string>
 
+//#define CD_POLYHEDRON_ALGORITHM_VERBOSE_MODE //VERBOSE mode (slows down the algorithm) default is commented
 
 using namespace sch;
 
@@ -296,6 +297,9 @@ Point3 Polyhedron_algorithms::support(const Vector3&v,int &lastFeature)const
     ///the best is te return the support computed using the naive version 
     if (iterations>numberOfVertices_) 
     {
+#ifdef CD_POLYHEDRON_ALGORITHM_VERBOSE_MODE
+      std::cout << "Problem Support Polyhedron, Naive method triggered" << std::endl;
+#endif
       return naiveSupport(v);
     }
   }

--- a/src/S_Polyhedron/S_PolyhedronVertex.cpp
+++ b/src/S_Polyhedron/S_PolyhedronVertex.cpp
@@ -82,7 +82,7 @@ bool S_PolyhedronVertex::isHere(const Vector3 &direction,const  Scalar &currents
     }
   }
 
-  return (currentsupportH >= nextVertexH_ + sch::epsilon);
+  return (currentsupportH + sch::epsilon10 >= nextVertexH_); /// epsilon checks ensure that the improvement of the new support point is substantial
 }
 
 
@@ -103,8 +103,7 @@ bool S_PolyhedronVertex::isHere(const Vector3 &direction)
     }
   }
 
-  if ((nextVertex_!=NULL)
-    &&(nextVertexH_>curVertexH_+sch::epsilon))
+  if ((nextVertex_ != NULL) && (nextVertexH_ > curVertexH_ + sch::epsilon10))
   {
     return false;
   }

--- a/src/S_Polyhedron/S_PolyhedronVertex.cpp
+++ b/src/S_Polyhedron/S_PolyhedronVertex.cpp
@@ -1,6 +1,6 @@
 #include <sch/S_Polyhedron/S_PolyhedronVertex.h>
 
-//#define POLYHEDRON_VERTEX_VERBOSE_MODE //VERBOSE mode (slows down the algorithm) default is commented
+//#define CD_POLYHEDRON_VERTEX_VERBOSE_MODE //VERBOSE mode (slows down the algorithm) default is commented
 
 using namespace sch;
 S_PolyhedronVertex::S_PolyhedronVertex(void):fastNeighbors_(NULL),endNeighbors_(NULL)
@@ -73,7 +73,7 @@ bool S_PolyhedronVertex::isHere(const Vector3 &direction,const  Scalar &currents
     temp=(*iterator_)->supportH(direction);
     if (temp>nextVertexH_)
     {
-#ifdef POLYHEDRON_VERTEX_VERBOSE_MODE
+#ifdef CD_POLYHEDRON_VERTEX_VERBOSE_MODE
       std::cout.precision(20);
       std::cout<<"new H "<<temp<<" last H "<<nextVertexH_<<std::endl;
 #endif

--- a/src/S_Polyhedron/S_PolyhedronVertex.cpp
+++ b/src/S_Polyhedron/S_PolyhedronVertex.cpp
@@ -82,7 +82,7 @@ bool S_PolyhedronVertex::isHere(const Vector3 &direction,const  Scalar &currents
     }
   }
 
-  return (currentsupportH>=nextVertexH_);
+  return (currentsupportH >= nextVertexH_ + sch::epsilon);
 }
 
 
@@ -91,8 +91,8 @@ bool S_PolyhedronVertex::isHere(const Vector3 &direction)
   S_PolyhedronVertex** iterator_;
   nextVertex_=NULL;
   Scalar temp;
-
-  nextVertexH_=direction*cordinates_;
+  double curVertexH_ = direction * cordinates_;
+  nextVertexH_ = curVertexH_;
 
   for (iterator_=fastNeighbors_; iterator_!=endNeighbors_; ++iterator_)
   {
@@ -103,7 +103,15 @@ bool S_PolyhedronVertex::isHere(const Vector3 &direction)
     }
   }
 
-  return (nextVertex_==NULL);
+  if ((nextVertex_!=NULL)
+    &&(nextVertexH_>curVertexH_+sch::epsilon))
+  {
+    return false;
+  }
+  else 
+  {
+    return true;
+  } 
 }
 
 unsigned S_PolyhedronVertex::getNumNeighbors()const


### PR DESCRIPTION
This PR deals with infinite loops in two ways

- Require a minimal improvement of the vertex to switch to it
- Detect infinite loops and switch to a deterministic time (naive) method.

Also 
-Fix warnings
-Modernize definitions