### PR TITLE
Add ::clone() to sch::S_Object

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
         compiler: ${{ matrix.compiler }}
         build-type: ${{ matrix.build-type }}
         options: -DSCH_BUILD_BSD:BOOL=${{ matrix.build-bsd }}
+        macos-options: -DCMAKE_CXX_STANDARD=11
     - name: Upload documentation
       # Only run on master branch and for one configuration
       if: matrix.os == 'ubuntu-18.04' && matrix.build-type == 'RelWithDebInfo' && matrix.compiler == 'gcc' && github.ref == 'refs/heads/master'

--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -3,18 +3,18 @@ name: conan packaging for sch-core
 on:
   repository_dispatch:
     types: [conan-master, conan-release]
-  push:
-    paths-ignore:
-      - "debian/**"
-      - ".github/workflows/package.yml"
-      - ".github/workflows/build.yml"
-    branches:
-      - '**'
-    tags:
-      - v*
-  pull_request:
-    branches:
-      - '**'
+  #push:
+  #  paths-ignore:
+  #    - "debian/**"
+  #    - ".github/workflows/package.yml"
+  #    - ".github/workflows/build.yml"
+  #  branches:
+  #    - '**'
+  #  tags:
+  #    - v*
+  #pull_request:
+  #  branches:
+  #    - '**'
 
 jobs:
   build:

--- a/.github/workflows/sources/package.yml
+++ b/.github/workflows/sources/package.yml
@@ -33,6 +33,9 @@ on:
       - '**'
     tags:
       - v*
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   # For a given tag vX.Y.Z, this checks:

--- a/include/sch/STP-BV/STP_BV.h
+++ b/include/sch/STP-BV/STP_BV.h
@@ -179,6 +179,7 @@ namespace sch
 
     SCH_API virtual STP_BV & operator=(const STP_BV&);
 
+    SCH_API virtual STP_BV * clone() const;
 
     SCH_API virtual Point3  l_Support(const Vector3& v, int& lastFeature)const;
 

--- a/include/sch/STP-BV/STP_BV_P.h
+++ b/include/sch/STP-BV/STP_BV_P.h
@@ -16,6 +16,8 @@ namespace sch
   public:
     SCH_API STP_BV_P(void);
 
+    SCH_API virtual STP_BV_P * clone() const;
+
     SCH_API virtual Point3  l_Support(const Vector3& v, int& lastFeature)const;
 
     /*!

--- a/include/sch/S_Object/S_Box.h
+++ b/include/sch/S_Object/S_Box.h
@@ -20,6 +20,7 @@ namespace sch
     SCH_API S_Box(Scalar width,Scalar height,Scalar depth);
     SCH_API virtual ~S_Box(void);
 
+    SCH_API virtual S_Box * clone() const;
 
     SCH_API virtual Point3  l_Support(const Vector3& v, int& lastFeature)const;
 

--- a/include/sch/S_Object/S_Capsule.h
+++ b/include/sch/S_Object/S_Capsule.h
@@ -12,6 +12,8 @@ namespace sch
     SCH_API S_Capsule(Point3 p1, Point3 p2, Scalar radius);
     SCH_API ~S_Capsule();
 
+    SCH_API virtual S_Capsule * clone() const;
+
     SCH_API const Point3 & getP1() const;
 
     SCH_API const Point3 & getP2() const;

--- a/include/sch/S_Object/S_Cone.h
+++ b/include/sch/S_Object/S_Cone.h
@@ -22,6 +22,8 @@ namespace sch
     SCH_API S_Cone(const Scalar& angle, const Scalar& height );
     SCH_API virtual ~S_Cone();
 
+    SCH_API virtual S_Cone * clone() const;
+
     SCH_API virtual Point3 l_Support(const Vector3& v, int& lastFeature)const;
 
     SCH_API virtual S_ObjectType getType() const;

--- a/include/sch/S_Object/S_Cylinder.h
+++ b/include/sch/S_Object/S_Cylinder.h
@@ -12,6 +12,8 @@ namespace sch
     SCH_API S_Cylinder(Point3 p1, Point3 p2, Scalar radius);
     SCH_API ~S_Cylinder();
 
+    SCH_API virtual S_Cylinder * clone() const;
+
     SCH_API const Point3 & getP1() const;
 
     SCH_API const Point3 & getP2() const;

--- a/include/sch/S_Object/S_Object.h
+++ b/include/sch/S_Object/S_Object.h
@@ -80,6 +80,11 @@ namespace sch
 
     SCH_API virtual Point3 l_Support(const Vector3& v, int& lastFeature)const=0;
 
+    /*!
+    *  \brief Returns a copy of this S_Object
+    */
+    SCH_API virtual S_Object * clone() const = 0;
+
   public:
 
     SCH_API S_Object(void);

--- a/include/sch/S_Object/S_Point.h
+++ b/include/sch/S_Object/S_Point.h
@@ -12,6 +12,8 @@ namespace sch
     SCH_API S_Point();
     SCH_API ~S_Point();
 
+    SCH_API virtual S_Point * clone() const;
+
     SCH_API void setDisplayRadius( Scalar r);
     SCH_API Scalar getDisplayRadius() const ;
 

--- a/include/sch/S_Object/S_Sphere.h
+++ b/include/sch/S_Object/S_Sphere.h
@@ -18,6 +18,8 @@ namespace sch
     SCH_API S_Sphere(const Scalar& radius);
     SCH_API virtual ~S_Sphere();
 
+    SCH_API virtual S_Sphere * clone() const;
+
     SCH_API virtual Point3 l_Support(const Vector3& v, int& lastFeature)const;
 
     SCH_API virtual S_ObjectType getType() const;

--- a/include/sch/S_Object/S_Superellipsoid.h
+++ b/include/sch/S_Object/S_Superellipsoid.h
@@ -15,6 +15,8 @@ namespace sch
     SCH_API S_Superellipsoid(Scalar a,Scalar b,Scalar c,Scalar epsilon1,Scalar epsilon2);
     SCH_API virtual ~S_Superellipsoid(void);
 
+    SCH_API virtual S_Superellipsoid * clone() const;
+
     SCH_API virtual Point3  l_Support(const Vector3& v, int& lastFeature)const;
 
     SCH_API virtual S_ObjectType getType() const;

--- a/include/sch/S_Polyhedron/S_Polyhedron.h
+++ b/include/sch/S_Polyhedron/S_Polyhedron.h
@@ -27,6 +27,8 @@ namespace sch
 
     SCH_API const S_Polyhedron& operator =(const S_Polyhedron&);
 
+    SCH_API virtual S_Polyhedron * clone() const;
+
     /*!
     * \brief loads the polyhedron from a file. the file must be in the format of Qhull qconvex output, called with these options :
     * \ "qconvex TI <input_filename> TO <output_filename> Qt o f"

--- a/src/STP-BV/STP_BV.cpp
+++ b/src/STP-BV/STP_BV.cpp
@@ -217,6 +217,11 @@ STP_BV & STP_BV::operator =(const STP_BV & bv)
   return *this;
 }
 
+STP_BV * STP_BV::clone() const
+{
+  return new STP_BV(*this);
+}
+
 void STP_BV::computeArcPointsBetween(const Point3& p1, const Point3& p2,
                                      const Point3& center, int step,
                                      std::vector<Point3>& res) const

--- a/src/STP-BV/STP_BV.cpp
+++ b/src/STP-BV/STP_BV.cpp
@@ -177,7 +177,8 @@ STP_BV::STP_BV()
 
 
 STP_BV::STP_BV(const STP_BV & bv)
-  :m_fastPatches(NULL)
+  :S_ObjectNormalized(bv),
+   m_fastPatches(NULL)
   ,m_lastPatches(NULL)
   ,geometries_(bv.geometries_)
 {
@@ -201,16 +202,18 @@ STP_BV::~STP_BV()
 
 STP_BV & STP_BV::operator =(const STP_BV & bv)
 {
-  if (&bv!=this)
+  if(&bv == this)
   {
-    m_patches.clear();
-    for (size_t i=0; i<bv.m_patches.size(); i++)
-    {
-      m_patches.push_back(bv.m_patches[i]->clone());
-    }
-    updateFastPatches();
-    geometries_ = bv.geometries_;
+    return *this;
   }
+  static_cast<S_ObjectNormalized &>(*this) = static_cast<const S_ObjectNormalized &>(bv);
+  m_patches.clear();
+  for (size_t i=0; i<bv.m_patches.size(); i++)
+  {
+    m_patches.push_back(bv.m_patches[i]->clone());
+  }
+  updateFastPatches();
+  geometries_ = bv.geometries_;
   return *this;
 }
 

--- a/src/STP-BV/STP_BV_P.cpp
+++ b/src/STP-BV/STP_BV_P.cpp
@@ -10,6 +10,11 @@ STP_BV_P::~STP_BV_P(void)
 {
 }
 
+STP_BV_P * STP_BV_P::clone() const
+{
+  return new STP_BV_P(*this);
+}
+
 void STP_BV_P::constructFromFile(const std::string &filename)
 {
   STP_BV::constructFromFile(filename);

--- a/src/S_Object/S_Box.cpp
+++ b/src/S_Object/S_Box.cpp
@@ -15,6 +15,11 @@ S_Box::~S_Box(void)
 {
 }
 
+S_Box * S_Box::clone() const
+{
+  return new S_Box(*this);
+}
+
 Point3  S_Box::l_Support(const Vector3& v, int& /*lastFeature*/)const
 {
   return Point3(sign(v[0])*a_,sign(v[1])*b_,sign(v[2])*c_);

--- a/src/S_Object/S_Capsule.cpp
+++ b/src/S_Object/S_Capsule.cpp
@@ -10,6 +10,11 @@ S_Capsule::~S_Capsule()
 {
 }
 
+S_Capsule * S_Capsule::clone() const
+{
+  return new S_Capsule(*this);
+}
+
 Point3 S_Capsule::l_Support(const Vector3& v, int& /*lastFeature*/)const
 {
   Point3 d(p2_);

--- a/src/S_Object/S_Cone.cpp
+++ b/src/S_Object/S_Cone.cpp
@@ -4,6 +4,10 @@
 
 using namespace sch;
 
+S_Cone * S_Cone::clone() const
+{
+  return new S_Cone(*this);
+}
 
 S_Cone::S_Cone(const Scalar& angle, const Scalar &  height) 
 

--- a/src/S_Object/S_Cylinder.cpp
+++ b/src/S_Object/S_Cylinder.cpp
@@ -2,6 +2,11 @@
 
 using namespace sch;
 
+S_Cylinder * S_Cylinder::clone() const
+{
+  return new S_Cylinder(*this);
+}
+
 S_Cylinder::S_Cylinder(Point3 p1, Point3 p2, Scalar radius): p1_(p1),p2_(p2),radius_(radius)
 {
   normal_ = p2_ - p1_;

--- a/src/S_Object/S_Point.cpp
+++ b/src/S_Object/S_Point.cpp
@@ -9,6 +9,11 @@ S_Point::~S_Point()
 {
 }
 
+S_Point * S_Point::clone() const
+{
+  return new S_Point(*this);
+}
+
 void S_Point::setDisplayRadius(Scalar r)
 {
   displayRadius_ = r;

--- a/src/S_Object/S_Sphere.cpp
+++ b/src/S_Object/S_Sphere.cpp
@@ -11,6 +11,10 @@ S_Sphere::~S_Sphere(void)
 {
 }
 
+S_Sphere * S_Sphere::clone() const
+{
+  return new S_Sphere(*this);
+}
 
 Point3 S_Sphere::l_Support(const Vector3& v, int& /*lastFeature*/)const
 {

--- a/src/S_Object/S_Superellipsoid.cpp
+++ b/src/S_Object/S_Superellipsoid.cpp
@@ -26,6 +26,11 @@ S_Superellipsoid::~S_Superellipsoid(void)
 {
 }
 
+S_Superellipsoid * S_Superellipsoid::clone() const
+{
+  return new S_Superellipsoid(*this);
+}
+
 Point3 S_Superellipsoid::l_Support(const Vector3& v, int& /*lastFeature*/)const
 {
   Scalar anx,bny,cnz;

--- a/src/S_Polyhedron/S_Polyhedron.cpp
+++ b/src/S_Polyhedron/S_Polyhedron.cpp
@@ -36,6 +36,11 @@ const S_Polyhedron& S_Polyhedron::operator =(const S_Polyhedron &p)
   return *this;
 }
 
+S_Polyhedron * S_Polyhedron::clone() const
+{
+  return new S_Polyhedron(*this);
+}
+
 void S_Polyhedron::updateVertexNeighbors()
 {
   poly.updateVertexNeighbors();

--- a/src/S_Polyhedron/S_Polyhedron.cpp
+++ b/src/S_Polyhedron/S_Polyhedron.cpp
@@ -17,7 +17,7 @@ S_Polyhedron::S_Polyhedron(void):poly()
 {
 }
 
-S_Polyhedron::S_Polyhedron(const S_Polyhedron& p):poly(p.poly)
+S_Polyhedron::S_Polyhedron(const S_Polyhedron& p): S_ObjectNonNormalized(p), poly(p.poly)
 {
 }
 
@@ -27,6 +27,11 @@ S_Polyhedron::~S_Polyhedron(void)
 
 const S_Polyhedron& S_Polyhedron::operator =(const S_Polyhedron &p)
 {
+  if(&p == this)
+  {
+    return *this;
+  }
+  static_cast<S_ObjectNonNormalized &>(*this) = static_cast<const S_ObjectNonNormalized &>(p);
   poly=p.poly;
   return *this;
 }

--- a/tests/clone_example_universe.h
+++ b/tests/clone_example_universe.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "shared-tests/examples/example_common.h"
+
+inline Example CloneUniverse(Example & in)
+{
+  Example out;
+  // Initialize the universe to have the correct names
+  out.initializeUniverse();
+  // Clear the scene
+  out.sObj = sch::CD_Scene();
+  for(size_t i = 0; i < in.sObj.size(); ++i)
+  {
+    out.sObj.addObject(in.sObj[i]->clone());
+  }
+  return out;
+}

--- a/tests/clone_example_universe.h
+++ b/tests/clone_example_universe.h
@@ -2,9 +2,8 @@
 
 #include "shared-tests/examples/example_common.h"
 
-inline Example CloneUniverse(Example & in)
+inline void CloneUniverse(Example & in, Example & out)
 {
-  Example out;
   // Initialize the universe to have the correct names
   out.initializeUniverse();
   // Clear the scene
@@ -13,5 +12,4 @@ inline Example CloneUniverse(Example & in)
   {
     out.sObj.addObject(in.sObj[i]->clone());
   }
-  return out;
 }

--- a/tests/clone_test_universe.h
+++ b/tests/clone_test_universe.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "shared-tests/tests/common.h"
+
+inline TestMaterial CloneUniverse(TestMaterial & in, bool nonSTPBV)
+{
+  TestMaterial out(nonSTPBV);
+  for(size_t i = 0; i < in.sObj.size(); ++i)
+  {
+    out.sObj.addObject(in.sObj[i]->clone());
+  }
+  return out;
+}

--- a/tests/clone_test_universe.h
+++ b/tests/clone_test_universe.h
@@ -2,12 +2,10 @@
 
 #include "shared-tests/tests/common.h"
 
-inline TestMaterial CloneUniverse(TestMaterial & in, bool nonSTPBV)
+inline void CloneUniverse(TestMaterial & in, TestMaterial & out)
 {
-  TestMaterial out(nonSTPBV);
   for(size_t i = 0; i < in.sObj.size(); ++i)
   {
     out.sObj.addObject(in.sObj[i]->clone());
   }
-  return out;
 }

--- a/tests/example_test.cpp
+++ b/tests/example_test.cpp
@@ -15,7 +15,8 @@ int main()
   universe.initializeUniverse();
   bool success = universe.unittest();
   {
-    Example clone_universe = CloneUniverse(universe);
+    Example clone_universe;
+    CloneUniverse(universe, clone_universe);
     success = clone_universe.unittest() && success;
   }
   return (success? 0:1);

--- a/tests/example_test.cpp
+++ b/tests/example_test.cpp
@@ -1,4 +1,4 @@
-#include "shared-tests/examples/example_common.h"
+#include "clone_example_universe.h"
 
 #ifdef ENABLE_SIGFPE
 # include <fenv.h>
@@ -14,6 +14,10 @@ int main()
   Example universe;
   universe.initializeUniverse();
   bool success = universe.unittest();
+  {
+    Example clone_universe = CloneUniverse(universe);
+    success = clone_universe.unittest() && success;
+  }
   return (success? 0:1);
 }
 

--- a/tests/test_animation.cpp
+++ b/tests/test_animation.cpp
@@ -1,6 +1,6 @@
 #define NON_STP_BV_OBJECTS true
 
-#include "shared-tests/tests/common.h"
+#include "clone_test_universe.h"
 
 #ifdef ENABLE_SIGFPE
 # include <fenv.h>
@@ -21,6 +21,10 @@ int main ()
   TestMaterial universe = TestMaterial(NON_STP_BV_OBJECTS );
   universe.initializeUniverse();
   universe.TestAnimation();
+  {
+    TestMaterial clone_universe = CloneUniverse(universe, NON_STP_BV_OBJECTS);
+    clone_universe.TestAnimation();
+  }
   return 0;
 }
 

--- a/tests/test_animation.cpp
+++ b/tests/test_animation.cpp
@@ -22,7 +22,8 @@ int main ()
   universe.initializeUniverse();
   universe.TestAnimation();
   {
-    TestMaterial clone_universe = CloneUniverse(universe, NON_STP_BV_OBJECTS);
+    TestMaterial clone_universe(NON_STP_BV_OBJECTS);
+    CloneUniverse(universe, clone_universe);
     clone_universe.TestAnimation();
   }
   return 0;

--- a/tests/test_general.cpp
+++ b/tests/test_general.cpp
@@ -1,6 +1,6 @@
 #define NON_STP_BV_OBJECTS true
 
-#include "shared-tests/tests/common.h"
+#include "clone_test_universe.h""
 
 #ifdef ENABLE_SIGFPE
 # include <fenv.h>
@@ -21,6 +21,10 @@ int main ()
   TestMaterial universe = TestMaterial(NON_STP_BV_OBJECTS);
   universe.initializeUniverse();
   universe.GeneralTest();
+  {
+    TestMaterial clone_universe = CloneUniverse(universe, NON_STP_BV_OBJECTS);
+    clone_universe.GeneralTest();
+  }
   return 0;
 }
 

--- a/tests/test_general.cpp
+++ b/tests/test_general.cpp
@@ -22,7 +22,8 @@ int main ()
   universe.initializeUniverse();
   universe.GeneralTest();
   {
-    TestMaterial clone_universe = CloneUniverse(universe, NON_STP_BV_OBJECTS);
+    TestMaterial clone_universe(NON_STP_BV_OBJECTS);
+    CloneUniverse(universe, clone_universe);
     clone_universe.GeneralTest();
   }
   return 0;

--- a/tests/test_precision.cpp
+++ b/tests/test_precision.cpp
@@ -22,7 +22,8 @@ int main ()
   universe.initializeUniverse();
   universe.TestPrecision();
   {
-    TestMaterial clone_universe = CloneUniverse(universe, NON_STP_BV_OBJECTS);
+    TestMaterial clone_universe(NON_STP_BV_OBJECTS);
+    CloneUniverse(universe, clone_universe);
     clone_universe.TestPrecision();
   }
   return 0;

--- a/tests/test_precision.cpp
+++ b/tests/test_precision.cpp
@@ -1,6 +1,6 @@
 #define NON_STP_BV_OBJECTS true
 
-#include "shared-tests/tests/common.h"
+#include "clone_test_universe.h"
 
 #ifdef ENABLE_SIGFPE
 # include <fenv.h>
@@ -21,6 +21,10 @@ int main ()
   TestMaterial universe = TestMaterial(NON_STP_BV_OBJECTS);
   universe.initializeUniverse();
   universe.TestPrecision();
+  {
+    TestMaterial clone_universe = CloneUniverse(universe, NON_STP_BV_OBJECTS);
+    clone_universe.TestPrecision();
+  }
   return 0;
 }
 

--- a/tests/test_random.cpp
+++ b/tests/test_random.cpp
@@ -23,7 +23,8 @@ int main ()
   universe.RandomTestSupportFunction();
   universe.RandomTestSupportFunctionAllObjects();
   {
-    TestMaterial clone_universe = CloneUniverse(universe, NON_STP_BV_OBJECTS);
+    TestMaterial clone_universe(NON_STP_BV_OBJECTS);
+    CloneUniverse(universe, clone_universe);
     clone_universe.RandomTestSupportFunction();
     clone_universe.RandomTestSupportFunctionAllObjects();
   }

--- a/tests/test_random.cpp
+++ b/tests/test_random.cpp
@@ -1,6 +1,6 @@
 #define NON_STP_BV_OBJECTS true
 
-#include "shared-tests/tests/common.h"
+#include "clone_test_universe.h"
 
 #ifdef ENABLE_SIGFPE
 # include <fenv.h>
@@ -22,6 +22,11 @@ int main ()
   universe.initializeUniverse();
   universe.RandomTestSupportFunction();
   universe.RandomTestSupportFunctionAllObjects();
+  {
+    TestMaterial clone_universe = CloneUniverse(universe, NON_STP_BV_OBJECTS);
+    clone_universe.RandomTestSupportFunction();
+    clone_universe.RandomTestSupportFunctionAllObjects();
+  }
 
   return 0;
 }


### PR DESCRIPTION
This adds a virtual clone method to S_Object so the objects can be copied from a pointer to `sch::S_Object`

The method is tested by cloning the universe in the unit tests. It actually revealed an issue in the implementation of S_Polyhedron and STP_BV copy operators which is also fixed by this PR