### PR TITLE
Support for polyhedron edges and more interface

### DIFF
--- a/include/sch/Matrix/SmallVector3T.h
+++ b/include/sch/Matrix/SmallVector3T.h
@@ -307,6 +307,14 @@ namespace CD_Matrix
       m_z *= in;
     }
 
+    /*! Normalized . */
+    inline Vector3T normalized() const
+    {
+      T in = static_cast<T>(1.0 / sqrt(m_x * m_x + m_y * m_y + m_z * m_z));
+
+      return Vector3T(m_x * in, m_y * in, m_z * in);
+    }
+
     /*! Get the norm. */
     inline T norm()  const
     {

--- a/include/sch/STP-BV/STP_BV.h
+++ b/include/sch/STP-BV/STP_BV.h
@@ -312,6 +312,16 @@ namespace sch
       ar & m_patchesSize ;
     }
 
+    Scalar getBigRadius() const
+    {
+      return _R;
+    }
+
+    Scalar getSmallRadius() const
+    {
+      return _r;
+    }
+
 
 
     BOOST_SERIALIZATION_SPLIT_MEMBER()
@@ -380,6 +390,8 @@ namespace sch
     STP_Feature * * m_fastPatches;
     STP_Feature * * m_lastPatches;
     int m_patchesSize;
+    Scalar _r,_R;
+
 
     std::vector<Geometry> geometries_;
   };

--- a/include/sch/S_Polyhedron/Polyhedron_algorithms.h
+++ b/include/sch/S_Polyhedron/Polyhedron_algorithms.h
@@ -96,7 +96,16 @@ namespace sch
 
     SCH_API void openFromFile(const std::string& filename);
 
+    /*!
+     *\brief Fill the edges_ variable using the data from the polyhedron
+     */
+
     SCH_API void fillEdges();
+
+    /*!
+     *\brief get the key of an edge computed automatically from its vertices
+     */
+
     SCH_API int getEdgeKey(PolyhedronEdge e);
 
     template<class Archive>

--- a/include/sch/S_Polyhedron/Polyhedron_algorithms.h
+++ b/include/sch/S_Polyhedron/Polyhedron_algorithms.h
@@ -7,7 +7,9 @@
 #include <sch/S_Polyhedron/S_PolyhedronVertex.h>
 
 #include <string>
+#include <algorithm>
 #include <vector>
+#include <set>
 
 namespace sch
 {
@@ -23,6 +25,27 @@ namespace sch
       ar & b;
       ar & c;
       ar & normal;
+    }
+  };
+
+  struct PolyhedronEdge
+  {
+    size_t a, b;
+    Vector3 edge;
+  public:
+    template<class Archive>
+    void serialize(Archive & ar, const unsigned int /*version*/)
+    {
+      ar & a;
+      ar & b;
+      ar & edge;
+    }
+    void computeEdge(const std::vector<S_PolyhedronVertex*> & v)
+    {
+      Vector3 p1, p2;
+      p1 = v[a]->getCoordinates();
+      p2 = v[b]->getCoordinates();
+      edge = p1-p2;
     }
   };
 
@@ -77,6 +100,9 @@ namespace sch
 
     SCH_API void openFromFile(const std::string& filename);
 
+    SCH_API void getEdges();
+    SCH_API int getEdgeKey(PolyhedronEdge e);
+
     template<class Archive>
     void serialize(Archive & ar, const unsigned int /*version*/)
     {
@@ -89,6 +115,7 @@ namespace sch
     std::vector<S_PolyhedronVertex*> vertexes_;
 
     std::vector<PolyhedronTriangle> triangles_;
+    std::vector<PolyhedronEdge> edges_;
 
     S_PolyhedronVertex **fastVertexes_;
     S_PolyhedronVertex ** lastVertexes_;

--- a/include/sch/S_Polyhedron/Polyhedron_algorithms.h
+++ b/include/sch/S_Polyhedron/Polyhedron_algorithms.h
@@ -97,7 +97,7 @@ namespace sch
 
     SCH_API void openFromFile(const std::string& filename);
 
-    SCH_API void getEdges();
+    SCH_API void fillEdges();
     SCH_API int getEdgeKey(PolyhedronEdge e);
 
     template<class Archive>

--- a/include/sch/S_Polyhedron/Polyhedron_algorithms.h
+++ b/include/sch/S_Polyhedron/Polyhedron_algorithms.h
@@ -106,7 +106,7 @@ namespace sch
      *\brief get the key of an edge computed automatically from its vertices
      */
 
-    SCH_API int getEdgeKey(PolyhedronEdge e);
+    SCH_API size_t getEdgeKey(PolyhedronEdge e);
 
     template<class Archive>
     void serialize(Archive & ar, const unsigned int /*version*/)

--- a/include/sch/S_Polyhedron/Polyhedron_algorithms.h
+++ b/include/sch/S_Polyhedron/Polyhedron_algorithms.h
@@ -39,9 +39,8 @@ namespace sch
     }
     void computeEdge(const std::vector<S_PolyhedronVertex*> & v)
     {
-      Vector3 p1, p2;
-      p1 = v[a]->getCoordinates();
-      p2 = v[b]->getCoordinates();
+      const Vector3 &p1 = v[a]->getCoordinates();
+      const Vector3 &p2 = v[b]->getCoordinates();
       edge = p1-p2;
     }
   };

--- a/include/sch/S_Polyhedron/Polyhedron_algorithms.h
+++ b/include/sch/S_Polyhedron/Polyhedron_algorithms.h
@@ -117,7 +117,7 @@ namespace sch
       //ar & lastVertexes_;
     }
 
-    std::vector<S_PolyhedronVertex*> vertexes_;
+    std::vector<S_PolyhedronVertex *> vertexes_;
 
     std::vector<PolyhedronTriangle> triangles_;
     std::vector<PolyhedronEdge> edges_;

--- a/include/sch/S_Polyhedron/Polyhedron_algorithms.h
+++ b/include/sch/S_Polyhedron/Polyhedron_algorithms.h
@@ -7,10 +7,7 @@
 #include <sch/S_Polyhedron/S_PolyhedronVertex.h>
 
 #include <string>
-#include <algorithm>
 #include <vector>
-#include <set>
-
 namespace sch
 {
   struct PolyhedronTriangle

--- a/src/STP-BV/STP_BV.cpp
+++ b/src/STP-BV/STP_BV.cpp
@@ -360,7 +360,6 @@ void STP_BV::constructFromFile(const std::string& filename)
   }
 
   //small spheres
-  Scalar _r,_R;
   is >>_r>>_R>> ssnum;
   if(ssnum <= 0)
   {

--- a/src/S_Polyhedron/Polyhedron_algorithms.cpp
+++ b/src/S_Polyhedron/Polyhedron_algorithms.cpp
@@ -72,8 +72,7 @@ const Polyhedron_algorithms& Polyhedron_algorithms::operator =(const Polyhedron_
   }
 }
 
-
-int Polyhedron_algorithms::getEdgeKey(PolyhedronEdge e)
+size_t Polyhedron_algorithms::getEdgeKey(PolyhedronEdge e)
 {
   return ((e.a<e.b)?(e.a*vertexes_.size()+e.b):(e.b*vertexes_.size()+e.a));
 }
@@ -83,7 +82,7 @@ void Polyhedron_algorithms::fillEdges()
   edges_.clear();
   PolyhedronEdge edge;
   std::vector<PolyhedronEdge> triangleEdges;
-  std::set<int, std::greater<int>> edgesSet;
+  std::set<size_t, std::greater<int>> edgesSet;
   for(size_t i = 0; i < triangles_.size(); i++)
   {
     edge.a = triangles_[i].a;

--- a/src/S_Polyhedron/Polyhedron_algorithms.cpp
+++ b/src/S_Polyhedron/Polyhedron_algorithms.cpp
@@ -71,6 +71,44 @@ const Polyhedron_algorithms& Polyhedron_algorithms::operator =(const Polyhedron_
 }
 
 
+int Polyhedron_algorithms::getEdgeKey(PolyhedronEdge e)
+{
+  return ((e.a<e.b)?(e.a*vertexes_.size()+e.b):(e.b*vertexes_.size()+e.a));
+}
+
+void Polyhedron_algorithms::getEdges()
+{
+  PolyhedronEdge edge;
+  std::vector<PolyhedronEdge> triangleEdges;
+  std::set<int, std::greater<int>> edgesSet;
+  for(size_t i = 0; i < triangles_.size(); i++)
+  {
+    edge.a = triangles_[i].a;
+    edge.b = triangles_[i].b;
+    edge.computeEdge(vertexes_);
+    triangleEdges.push_back(edge);
+    
+    edge.a = triangles_[i].b;
+    edge.b = triangles_[i].c;
+    edge.computeEdge(vertexes_);
+    triangleEdges.push_back(edge);
+    
+    edge.a = triangles_[i].c;
+    edge.b = triangles_[i].a;
+    edge.computeEdge(vertexes_);
+    triangleEdges.push_back(edge);
+
+    for(auto j = triangleEdges.begin(); j != triangleEdges.end(); j++)
+    {
+      if(!edgesSet.count(getEdgeKey(*j)))
+      {
+        edges_.push_back(*j);
+        edgesSet.insert(getEdgeKey(*j));
+      }
+    }
+    triangleEdges.clear();
+  }
+}
 
 void Polyhedron_algorithms::openFromFile(const std::string &filename)
 {
@@ -114,6 +152,8 @@ void Polyhedron_algorithms::openFromFile(const std::string &filename)
   const char normalSearch[normalSearchLen + 1] = "    - normal:";
   const size_t verticesSearchLen = 15;
   const char verticesSearch[verticesSearchLen + 1] = "    - vertices:";
+  PolyhedronEdge edge;
+  Vector3 p1, p2;
   while(std::getline(is, line).good())
   {
     if(line.substr(0, normalSearchLen) == normalSearch)
@@ -171,6 +211,8 @@ void Polyhedron_algorithms::openFromFile(const std::string &filename)
   }
 
   deleteVertexesWithoutNeighbors();
+
+  getEdges();
 }
 
 void Polyhedron_algorithms::updateVertexNeighbors()

--- a/src/S_Polyhedron/Polyhedron_algorithms.cpp
+++ b/src/S_Polyhedron/Polyhedron_algorithms.cpp
@@ -155,7 +155,7 @@ void Polyhedron_algorithms::openFromFile(const std::string &filename)
   const size_t verticesSearchLen = 15;
   const char verticesSearch[verticesSearchLen + 1] = "    - vertices:";
   PolyhedronEdge edge;
-  Vector3 p1, p2;
+
   while(std::getline(is, line).good())
   {
     if(line.substr(0, normalSearchLen) == normalSearch)

--- a/src/S_Polyhedron/Polyhedron_algorithms.cpp
+++ b/src/S_Polyhedron/Polyhedron_algorithms.cpp
@@ -154,7 +154,6 @@ void Polyhedron_algorithms::openFromFile(const std::string &filename)
   const char normalSearch[normalSearchLen + 1] = "    - normal:";
   const size_t verticesSearchLen = 15;
   const char verticesSearch[verticesSearchLen + 1] = "    - vertices:";
-  PolyhedronEdge edge;
 
   while(std::getline(is, line).good())
   {

--- a/src/S_Polyhedron/Polyhedron_algorithms.cpp
+++ b/src/S_Polyhedron/Polyhedron_algorithms.cpp
@@ -78,7 +78,7 @@ int Polyhedron_algorithms::getEdgeKey(PolyhedronEdge e)
   return ((e.a<e.b)?(e.a*vertexes_.size()+e.b):(e.b*vertexes_.size()+e.a));
 }
 
-void Polyhedron_algorithms::getEdges()
+void Polyhedron_algorithms::fillEdges()
 {
   edges_.clear();
   PolyhedronEdge edge;
@@ -215,7 +215,7 @@ void Polyhedron_algorithms::openFromFile(const std::string &filename)
 
   deleteVertexesWithoutNeighbors();
 
-  getEdges();
+  fillEdges();
 }
 
 void Polyhedron_algorithms::updateVertexNeighbors()

--- a/src/S_Polyhedron/Polyhedron_algorithms.cpp
+++ b/src/S_Polyhedron/Polyhedron_algorithms.cpp
@@ -5,6 +5,8 @@
 #include <fstream>
 #include <stdexcept>
 #include <string>
+#include <algorithm>
+#include <set>
 
 //#define CD_POLYHEDRON_ALGORITHM_VERBOSE_MODE //VERBOSE mode (slows down the algorithm) default is commented
 

--- a/src/S_Polyhedron/Polyhedron_algorithms.cpp
+++ b/src/S_Polyhedron/Polyhedron_algorithms.cpp
@@ -80,6 +80,7 @@ int Polyhedron_algorithms::getEdgeKey(PolyhedronEdge e)
 
 void Polyhedron_algorithms::getEdges()
 {
+  edges_.clear();
   PolyhedronEdge edge;
   std::vector<PolyhedronEdge> triangleEdges;
   std::set<int, std::greater<int>> edgesSet;
@@ -246,6 +247,7 @@ void Polyhedron_algorithms::clear()
   }
   vertexes_.clear();
   triangles_.clear();
+  edges_.clear();
   updateFastArrays();
 }
 


### PR DESCRIPTION
This PR introdces features requires by the optimal construction method in sch-creatot

- add extraction of the list of edges from the output file of qconvex.
- make the radii of STP BV accessible after the object has been built.
- add some interface to vector3T
