### PR TITLE
[cd_pair] Add a getter for the last direction vector

### DIFF
--- a/include/sch/CD/CD_Pair.h
+++ b/include/sch/CD/CD_Pair.h
@@ -61,6 +61,11 @@ namespace sch
     *\brief Intializes the direction vector (the vector between expected closest points) with a given value.
     */
     SCH_API void setVector(const Vector3 &);
+    
+    /*!
+    *\brief Gets the last direction vector (can be used to get a normal vector, especially when the distance is zero)
+    */
+    SCH_API const Vector3 & getVector() const;
 
     /*!
     *\brief sets the relative precision of the proximity queries to a given value. The effective precision is precision^2 . Default is precision=1e-3.

--- a/src/CD/CD_Pair.cpp
+++ b/src/CD/CD_Pair.cpp
@@ -363,6 +363,11 @@ void CD_Pair::setVector(const Vector3 &v)
   lastDirection_=v;
 }
 
+const Vector3 & CD_Pair::getVector() const 
+{
+  return lastDirection_;
+}
+
 void CD_Pair::witPoints(Point3 &p1, Point3 &p2)
 {
   Point3 proj;


### PR DESCRIPTION
This PR allows to add a way to obtain the last direction vector used when calculating the distance. It may be useful for example to get a separating direction when the distance is zero.