### PR TITLE
Set default witnesses in case of collision

### DIFF
--- a/examples/example0.cpp
+++ b/examples/example0.cpp
@@ -179,8 +179,8 @@ main (int /*argc*/, char * /*argv*/[])
   comparison = compare(d1, 0., "Second query, d1. ") && comparison;
 #ifdef SCH_BUILD_BSD
   comparison = compare(d2, 0., "Second query, d2. ") && comparison;
-  comparison = compare(p1, (Vector3(0.0292236259885692, 0.601445137095698, 0.705635281288737)), "Second query, p1. ") && comparison;
-  comparison = compare(p2, (Vector3(0.0239874216806999, -0.336387177086141, -0.781275504057127)), "Second query, p2. ") && comparison;
+  comparison = compare(p1, (Vector3(-0.211100297803413, -0.0866553324786505, -0.0206764992279858)), "Second query, p1. ") && comparison;
+  comparison = compare(p2, (Vector3(0.201035958824805, -0.171232378087511, 0.066080909954798)), "Second query, p2. ") && comparison;
 #else
   comparison = compare(d2, 0.293744618861213, "Second query, d2. ") && comparison;
   comparison = compare(p1, (Vector3(0.0110146674327551, -0.0498945075944604, -0.0551780527427314)), "Second query, p1. ") && comparison;
@@ -216,8 +216,8 @@ main (int /*argc*/, char * /*argv*/[])
   // compare the results for third query
 #ifdef SCH_BUILD_BSD
   comparison = compare(d0, 0., "Third Query, d0") && comparison;
-  comparison = compare(p1, (Vector3(0.0292236259885692, 0.601445137095698, 0.705635281288737)), "Third Query, p1") && comparison;
-  comparison = compare(p2, (Vector3(0.0239874216806999, -0.336387177086141, -0.781275504057127)), "Third Query, p2") && comparison;
+  comparison = compare(p1, (Vector3(-0.211100297803413, -0.0866553324786505, -0.0206764992279858)), "Third Query, p1") && comparison;
+  comparison = compare(p2, (Vector3(0.201035958824805, -0.171232378087511, 0.066080909954798)), "Third Query, p2") && comparison;
 #else
   comparison = compare(d0, -0.0862859011099191, "Third Query, d0") && comparison;
   comparison = compare(p1, (Vector3(0.0110146674327551, -0.0498945075944604, -0.0551780527427314)), "Third Query, p1") && comparison;

--- a/include/sch/CD/CD_Pair.h
+++ b/include/sch/CD/CD_Pair.h
@@ -61,10 +61,11 @@ namespace sch
     *\brief Intializes the direction vector (the vector between expected closest points) with a given value.
     */
     SCH_API void setVector(const Vector3 &);
-    
+
     /*!
-    *\brief Gets the last direction vector (can be used to get a normal vector, especially when the distance is zero)
-    */
+     *\brief Gets the last direction vector (can be used to get a normal vector, especially when the distance is zero).
+     * This vector is likely NOT normalized
+     */
     SCH_API const Vector3 & getVector() const;
 
     /*!

--- a/include/sch/CD/CD_Pair.h
+++ b/include/sch/CD/CD_Pair.h
@@ -28,7 +28,7 @@ namespace sch
 
     /*!
     *\brief function that returns the distance SQUARED between two convex objects, and computes the witness points, the distance is set to negative if interpentration
-    *\details The witness points are on the surface of the objects with opposite normals. Iif there is a collision and the penetration depth computation is deactivated 
+    *\details The witness points are on the surface of the objects with opposite normals. If there is a collision and the penetration depth computation is deactivated 
     * then the witness points will only reflect the last step of the distance computation algorithm. Otherwise the witness points are points each on the surface of the other,
     *  having opposite normals and being the closest each to the other. In any case the returned distance should be used to obtain the distance.
     *\param p1 is the witness point on the first object

--- a/include/sch/CD/CD_Pair.h
+++ b/include/sch/CD/CD_Pair.h
@@ -28,10 +28,14 @@ namespace sch
 
     /*!
     *\brief function that returns the distance SQUARED between two convex objects, and computes the witness points, the distance is set to negative if interpentration
+    *\details The witness points are on the surface of the objects with opposite normals. Iif there is a collision and the penetration depth computation is deactivated 
+    * then the witness points will only reflect the last step of the distance computation algorithm. Otherwise the witness points are points each on the surface of the other,
+    *  having opposite normals and being the closest each to the other. In any case the returned distance should be used to obtain the distance.
     *\param p1 is the witness point on the first object
     *\param p2 is the witness point on the second object
+    *\return the distance squared (set to negative when there is penetration)
     */
-    SCH_API Scalar getClosestPoints(Point3& p1,Point3& p2);
+    SCH_API Scalar getClosestPoints(Point3 &p1, Point3 &p2);
 
     /*!
     *\brief function that returns the distance SQUARED between two convex objects, restarting the computations from the beginning and computes the witness points, the distance is set to negative if interpentration

--- a/src/CD/CD_Pair.cpp
+++ b/src/CD/CD_Pair.cpp
@@ -319,7 +319,7 @@ Scalar CD_Pair::GJK()
             s1+=sup1;
             s2+=sup2;
 
-            if (sp_.getType()==CD_Tetrahedron)
+            if (sp_.getType() == CD_Tetrahedron) // the origin is in the Minkovsky sum
             {
               cont=false;
               s1+=sup1;

--- a/src/CD/CD_Pair.cpp
+++ b/src/CD/CD_Pair.cpp
@@ -141,12 +141,7 @@ Scalar CD_Pair::penetrationDepth()
 #ifdef PENETRATION_DEPTH
   if (collision_)//Objects are in collision
   {
-    distance_=-depthPair.getPenetrationDepth(lastDirection_,p1_,p2_,sp_,s1_,s2_);
-    if (distance_<0)
-    {
-      lastDirection_.Set(0,1,0);
-    }
-
+    distance_ = -depthPair.getPenetrationDepth(lastDirection_, p1_, p2_, sp_, s1_, s2_);
     return distance_;
   }
   else

--- a/src/CD/CD_Pair.cpp
+++ b/src/CD/CD_Pair.cpp
@@ -275,6 +275,8 @@ Scalar CD_Pair::GJK()
       {
         collision_=true;
         cont=false;
+        p1_ = sup1; ///despite the collision we set the witness points rather than nothing
+        p2_ = sup2;
       }
       else
       {
@@ -326,6 +328,8 @@ Scalar CD_Pair::GJK()
               s2+=sup2;
               collision_=true;
               distance_=0.;
+              p1_ = sup1; ///despite the collision we set these witness points rather than nothing
+              p2_ = sup2;
             }
             else
             {

--- a/src/CD/CD_Pair.cpp
+++ b/src/CD/CD_Pair.cpp
@@ -116,8 +116,11 @@ Scalar CD_Pair::getClosestPoints(Point3 &p1, Point3 &p2)
       witPointsAreComputed_=true;
       witPoints(p1,p2);
     }
-    p1=p1_;
-    p2=p2_;
+    else
+    {
+      p1 = p1_;
+      p2 = p2_;
+    }
     return distance_;
   }
   else

--- a/src/CD_Penetration/CD_Depth.cpp
+++ b/src/CD_Penetration/CD_Depth.cpp
@@ -51,7 +51,7 @@ struct TriangleHeap
       std::push_heap(&triangleHeap[0], &triangleHeap[num_triangles], triangleComp);
 #ifdef sch_DEBUG
       std::cout << " accepted" << std::endl;
-#endif
+#endif // ndefsch_DEBUG
     }
     else
     {
@@ -66,7 +66,7 @@ struct TriangleHeap
         std::cout << "triangle is further than upper bound";
       }
       std::cout << std::endl;
-#endif
+#endif // ndef sch_DEBUG
     }
   }
 
@@ -142,7 +142,7 @@ Scalar CD_Depth::getPenetrationDepth(Vector3&, Point3&, Point3&, const CD_Simple
 {
   return 0;
 }
-#else
+#else // def SCH_BUILD_BSD
 Scalar CD_Depth::getPenetrationDepth(Vector3& v, Point3 &p1,  Point3 &p2,const CD_SimplexEnhanced& s,
                                      const CD_Simplex& s1_, const CD_Simplex& s2_)
 {
@@ -387,7 +387,7 @@ Scalar CD_Depth::getPenetrationDepth(Vector3& v, Point3 &p1,  Point3 &p2,const C
       {
 #ifdef sch_DEBUG
         std::cout << "Ouch, no convergence!!!" << std::endl;
-#endif
+#endif //def sch_DEBUG
         assert(false);
         break;
       }
@@ -410,11 +410,9 @@ Scalar CD_Depth::getPenetrationDepth(Vector3& v, Point3 &p1,  Point3 &p2,const C
       Scalar error = far_dist - triangle->getDist2();
       if (error <= GEN_max(precision_ * far_dist, epsilon_)
 #if 1
-          || yBuf[index] == yBuf[(*triangle)[0]]
-          || yBuf[index] == yBuf[(*triangle)[1]]
-          || yBuf[index] == yBuf[(*triangle)[2]]
-#endif
-         )
+          || yBuf[index] == yBuf[(*triangle)[0]] || yBuf[index] == yBuf[(*triangle)[1]] || yBuf[index] == yBuf[(*triangle)[2]]
+#endif // 1
+      )
       {
         break;
       }
@@ -448,15 +446,14 @@ Scalar CD_Depth::getPenetrationDepth(Vector3& v, Point3 &p1,  Point3 &p2,const C
 
 #ifdef sch_DEBUG
   std::cout << "#triangles left = " << num_triangles << std::endl;
-#endif
+#endif //def sch_DEBUG
 
   v = triangle->getClosest();
   p1 = triangle->getClosestPoint(pBuf);
   p2 = triangle->getClosestPoint(qBuf);
   return v.normsquared();
 }
-#endif
-
+#endif // def SCH_BUILD_BSD
 
 CD_Depth::CD_Depth(S_Object *Obj1, S_Object *Obj2):sObj1_(Obj1),sObj2_(Obj2),precision_(defaultPrecision),epsilon_(sch::epsilon)
 {


### PR DESCRIPTION
This PR changes the behavior of CD_Pair::getClosestPoints, in order to provide a default value of the witness points in case of collision when the penetration depth computation is disabled.

The new behavior will provide the last computed support points that were computed before the collision was detected. It should provide a better direction to separate the objects than a random set of points.